### PR TITLE
Passierschein A38: Anderes Video, wo man den Anfang und das Ende noch sieht

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -1229,7 +1229,7 @@ Das [Agile Manifesto](https://agilemanifesto.org) zielt nicht darauf ab, die Ele
   - "Schick mir das als Excel-Formular"
   - Meeting planen, wenn man auch schnell aushelfen kann
   - alle müssen zwischen 9 und 16 Uhr im Büro sein
-  - [Passierschein A38](https://www.youtu.be/8yrRVrADW-0&t=1m)
+  - [Passierschein A38](https://youtu.be/8yrRVrADW-0&t=1m)
 - Beharren auf Hierarchien
 - ungeeignete Metriken für Beurteilung des Outputs
 

--- a/slides.md
+++ b/slides.md
@@ -1229,7 +1229,7 @@ Das [Agile Manifesto](https://agilemanifesto.org) zielt nicht darauf ab, die Ele
   - "Schick mir das als Excel-Formular"
   - Meeting planen, wenn man auch schnell aushelfen kann
   - alle müssen zwischen 9 und 16 Uhr im Büro sein
-  - [Passierschein A38](https://www.youtube.com/watch?v=NQV6PA6BOVE)
+  - [Passierschein A38](https://www.youtu.be/8yrRVrADW-0&t=1m)
 - Beharren auf Hierarchien
 - ungeeignete Metriken für Beurteilung des Outputs
 


### PR DESCRIPTION
Bei diesem Upload sieht man noch mehr vor und nach der Szene (z.B.: Die Leute, die die ganze Bürokratie mitgemacht haben sind jetzt verrückt). Außerdem wurde etwas rein gezoomt, sodass die schwarzen Balken nicht mehr ganz so groß sind. Jedoch ist ein wenig oben und unten abgeschnitten (man sieht trotzdem die gesamte Handlung).