### PR TITLE
Open Source vs. Free Software: Korrektur

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -2829,14 +2829,13 @@ Vier essentielle Freiheiten:
 
 ### Open Source vs. Free Software
 
-Beispiel: Visual Studio Code ist [Open Source](https://github.com/Microsoft/vscode), aber [nicht frei](https://code.visualstudio.com/License/):
+Die Open Source und Free Software Definitionen sind fast deckungsgleich, sodass Open Source Lizenzen und Programme in der Regel auch freie Software sind und umgekehrt.
 
-> The software may collect information about you (...) You may opt-out of many of these scenarios, but not all (...)
-> You may not remove, minimize, block or modify any notices of Microsoft or its suppliers in the software (...)
+Hinter den beiden Definitionen stehen jedoch sehr unterschiedliche Philosophien und Motivationen: Während freie Software das Ziel hat die Freiheiten der Benutzer zu verteidigen fokussiert sich die Open Source Bewegung auf die praktischen Vorteile, welche sich durch uneingeschränkte Zusammenarbeit ergeben können.
 
-[Richard Stallman](https://www.gnu.org/philosophy/open-source-misses-the-point.en.html):
+Der Begriff _Free and Open Source Software (FOSS)_ hat den Anspruch beide Bewegungen zusammenzufassen und gleichzeitig politisch eher neutral zu sein.
 
-> Your program is very attractive, but I value my freedom more. So I reject your program. I will get my work done some other way, and support a project to develop a free replacement.
+Quelle: [opensource.com](https://opensource.com/article/17/11/open-source-or-free-software)
 
 ---
 


### PR DESCRIPTION
Die Binärdateien für VS Code, welche von Microsoft angeboten werden,
sind proprietär und damit weder Open Source Software noch freie
Software. Der Quellcode von VS Code, den Microsoft auf GitHub zur
Verfügung stellt, sowie die daraus kompilierten Binärdateien des
VSCodium (https://vscodium.com) Projekts hingegen stehen unter der MIT
Lizenz und sind damit sowohl Open Source Software als auch freie
Software. Dies stimmt auch mit den Angaben auf der Wikipedia Seite von
VS Code (https://de.wikipedia.org/wiki/Visual_Studio_Code) überein.

Richard Stallman bezieht sich in der zitierten Aussage auf proprietäre
Software und nicht (wie hier impliziert) auf Open Source Software. Dies
geht aus den beiden vorausgehenden Absätzen des Artikels hervor.